### PR TITLE
chore: release v0.2.0

### DIFF
--- a/bundle.md
+++ b/bundle.md
@@ -1,7 +1,7 @@
 ---
 bundle:
   name: systems-design
-  version: 0.1.0
+  version: 0.2.0
   description: Systems design methodology for agentic development — structured design output with tradeoff analysis, multiscale reasoning, and failure mode coverage.
 
 includes:
@@ -14,10 +14,12 @@ includes:
 You have access to a systems design methodology that produces structured, rigorous architectural output.
 
 @systems-design:context/instructions.md
-@systems-design:context/system-design-principles.md
-@systems-design:context/tradeoff-frame.md
-@systems-design:context/adversarial-perspectives.md
-@systems-design:context/structured-design-template.md
+
+<!-- The methodology, tradeoff frame, adversarial perspectives, design review questions,
+     and structured design template are mode-gated: they load when /systems-design or
+     /systems-design-review is active. Standing-order in instructions.md tells the LLM
+     when to suggest entering a mode. -->
+
 
 ---
 

--- a/modes/systems-design.md
+++ b/modes/systems-design.md
@@ -89,3 +89,5 @@ they wouldn't have activated a mode. Follow the methodology.
 @systems-design:context/system-design-principles.md
 
 @systems-design:context/design-review-questions.md
+
+@systems-design:context/structured-design-template.md


### PR DESCRIPTION
## Summary
Migrate heavy methodology context from always-on into mode-contributed loading, reducing always-on token cost when no design mode is active by ~3,500 tokens (real: ~5K).

## Changes

### bundle.md
Removed 4 context file @-mentions:
- `@systems-design:context/system-design-principles.md`
- `@systems-design:context/tradeoff-frame.md`
- `@systems-design:context/adversarial-perspectives.md`
- `@systems-design:context/structured-design-template.md`

Kept `@systems-design:context/instructions.md` as always-on standing-order file.
Added explanatory comment on why methodology context is mode-gated.

### modes/systems-design.md
Added one @-mention to mode-body context group: `@systems-design:context/structured-design-template.md`

Other three context files were already referenced in the mode body via @-mentions; removing from bundle.md fixes the double-load.

## Rationale
This pattern aligns with the design-discipline rule from amplifier-bundle-modes/skills/mode-design-discipline/SKILL.md §1: heavy reference docs that are only relevant during a specific workflow belong in mode contributions, not always-on bundle context.

When neither /systems-design nor /systems-design-review is active, the methodology content does not load. When a mode IS active, the content loads as before via mode body contributions. 

No breaking changes — existing mode activations continue to work as before.